### PR TITLE
feat: use reserved public ip address on OCI

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -18,10 +18,18 @@ module "compute" {
   ssh_public_key = var.server_ssh_public_key
 }
 
+module "public_ip" {
+  source = "./modules/public_ip"
+
+  compartment_id = var.oci_compartment_id
+  subnet_id      = module.network.subnet_id
+  private_ip     = module.compute.private_ip
+}
+
 module "dns" {
   source = "./modules/dns"
 
   zone_id   = var.cloudflare_zone_id
   subdomain = var.server_subdomain
-  target    = module.compute.public_ip
+  target    = module.public_ip.public_ip
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -29,7 +29,7 @@ module "public_ip" {
 module "dns" {
   source = "./modules/dns"
 
-  zone_id   = var.cloudflare_zone_id
+  domain    = var.cloudflare_domain
   subdomain = var.server_subdomain
   target    = module.public_ip.public_ip
 }

--- a/infrastructure/modules/compute/main.tf
+++ b/infrastructure/modules/compute/main.tf
@@ -24,9 +24,10 @@ resource "oci_core_instance" "instance" {
   create_vnic_details {
     subnet_id = var.subnet_id
 
-    assign_public_ip          = true
+    assign_public_ip          = false
     assign_ipv6ip             = false
     assign_private_dns_record = false
+    skip_source_dest_check    = true
   }
 
   availability_config {

--- a/infrastructure/modules/compute/outputs.tf
+++ b/infrastructure/modules/compute/outputs.tf
@@ -1,5 +1,4 @@
 output "private_ip" {
   description = "The private IP address of the instance"
   value       = oci_core_instance.instance.private_ip
-  sensitive   = true
 }

--- a/infrastructure/modules/compute/outputs.tf
+++ b/infrastructure/modules/compute/outputs.tf
@@ -1,5 +1,5 @@
-output "public_ip" {
-  description = "The public IP address of the instance"
-  value       = oci_core_instance.instance.public_ip
+output "private_ip" {
+  description = "The private IP address of the instance"
+  value       = oci_core_instance.instance.private_ip
   sensitive   = true
 }

--- a/infrastructure/modules/compute/variables.tf
+++ b/infrastructure/modules/compute/variables.tf
@@ -1,13 +1,11 @@
 variable "compartment_id" {
   description = "OCID of the compartment in which to create the resources"
   type        = string
-  sensitive   = true
 }
 
 variable "subnet_id" {
   description = "OCID of the subnet in which to create the instance"
   type        = string
-  sensitive   = true
 }
 
 variable "name_suffix" {
@@ -69,5 +67,4 @@ variable "boot_volume_size_in_gbs" {
 variable "ssh_public_key" {
   description = "SSH public key allowed to connect to the instance"
   type        = string
-  sensitive   = true
 }

--- a/infrastructure/modules/dns/locals.tf
+++ b/infrastructure/modules/dns/locals.tf
@@ -1,3 +1,0 @@
-locals {
-  ttl = var.is_proxied ? 1 : var.ttl
-}

--- a/infrastructure/modules/dns/main.tf
+++ b/infrastructure/modules/dns/main.tf
@@ -1,5 +1,5 @@
 resource "cloudflare_dns_record" "dns_record" {
-  zone_id = var.zone_id
+  zone_id = data.cloudflare_zone.zone.id
 
   type    = "A"
   name    = var.subdomain

--- a/infrastructure/modules/dns/main.tf
+++ b/infrastructure/modules/dns/main.tf
@@ -5,5 +5,5 @@ resource "cloudflare_dns_record" "dns_record" {
   name    = var.subdomain
   content = var.target
   proxied = false
-  ttl     = local.ttl
+  ttl     = var.ttl
 }

--- a/infrastructure/modules/dns/main.tf
+++ b/infrastructure/modules/dns/main.tf
@@ -4,6 +4,6 @@ resource "cloudflare_dns_record" "dns_record" {
   type    = "A"
   name    = var.subdomain
   content = var.target
-  proxied = var.is_proxied
+  proxied = false
   ttl     = local.ttl
 }

--- a/infrastructure/modules/dns/main.tf
+++ b/infrastructure/modules/dns/main.tf
@@ -1,5 +1,5 @@
 resource "cloudflare_dns_record" "dns_record" {
-  zone_id = data.cloudflare_zone.zone.id
+  zone_id = data.cloudflare_zones.zone.result.0.id
 
   type    = "A"
   name    = var.subdomain

--- a/infrastructure/modules/dns/outputs.tf
+++ b/infrastructure/modules/dns/outputs.tf
@@ -1,0 +1,4 @@
+output "full_domain" {
+  description = "The full domain name"
+  value       = "${var.subdomain}.${var.domain}"
+}

--- a/infrastructure/modules/dns/sources.tf
+++ b/infrastructure/modules/dns/sources.tf
@@ -1,0 +1,3 @@
+data "cloudflare_zone" "zone" {
+  name = var.domain
+}

--- a/infrastructure/modules/dns/sources.tf
+++ b/infrastructure/modules/dns/sources.tf
@@ -1,3 +1,3 @@
-data "cloudflare_zone" "zone" {
+data "cloudflare_zones" "zone" {
   name = var.domain
 }

--- a/infrastructure/modules/dns/variables.tf
+++ b/infrastructure/modules/dns/variables.tf
@@ -16,14 +16,8 @@ variable "target" {
   sensitive   = true
 }
 
-variable "is_proxied" {
-  description = "Whether the record is proxied by Cloudflare"
-  type        = bool
-  default     = true
-}
-
 variable "ttl" {
-  description = "TTL of the record (if not proxied)"
+  description = "TTL of the record"
   type        = number
   default     = 3600
 }

--- a/infrastructure/modules/dns/variables.tf
+++ b/infrastructure/modules/dns/variables.tf
@@ -1,19 +1,16 @@
 variable "zone_id" {
   description = "ID of the domain to create the record in"
   type        = string
-  sensitive   = true
 }
 
 variable "subdomain" {
   description = "Subdomain to create the record for"
   type        = string
-  sensitive   = true
 }
 
 variable "target" {
   description = "Public IP address to point the record to"
   type        = string
-  sensitive   = true
 }
 
 variable "ttl" {

--- a/infrastructure/modules/dns/variables.tf
+++ b/infrastructure/modules/dns/variables.tf
@@ -1,5 +1,5 @@
-variable "zone_id" {
-  description = "ID of the domain to create the record in"
+variable "domain" {
+  description = "Domain to create the record for"
   type        = string
 }
 

--- a/infrastructure/modules/network/outputs.tf
+++ b/infrastructure/modules/network/outputs.tf
@@ -1,5 +1,4 @@
 output "subnet_id" {
   description = "OCID of the subnet"
   value       = oci_core_subnet.subnet.id
-  sensitive   = true
 }

--- a/infrastructure/modules/network/variables.tf
+++ b/infrastructure/modules/network/variables.tf
@@ -1,7 +1,6 @@
 variable "compartment_id" {
   description = "OCID of the compartment in which to create the resources"
   type        = string
-  sensitive   = true
 }
 
 variable "name_suffix" {
@@ -32,7 +31,6 @@ variable "subnet_cidr_block" {
 variable "server_port" {
   description = "Server port to allow TCP/UDP traffic to"
   type        = number
-  sensitive   = true
 
   validation {
     condition     = var.server_port > 0 && var.server_port < 65536

--- a/infrastructure/modules/public_ip/main.tf
+++ b/infrastructure/modules/public_ip/main.tf
@@ -2,5 +2,5 @@ resource "oci_core_public_ip" "public_ip" {
   compartment_id = var.compartment_id
 
   lifetime      = "RESERVED"
-  private_ip_id = data.oci_core_private_ips.private_ip.0.id
+  private_ip_id = data.oci_core_private_ips.private_ip.private_ips.0.id
 }

--- a/infrastructure/modules/public_ip/main.tf
+++ b/infrastructure/modules/public_ip/main.tf
@@ -1,0 +1,6 @@
+resource "oci_core_public_ip" "public_ip" {
+  compartment_id = var.compartment_id
+
+  lifetime      = "RESERVED"
+  private_ip_id = data.oci_core_private_ips.private_ip.0.id
+}

--- a/infrastructure/modules/public_ip/outputs.tf
+++ b/infrastructure/modules/public_ip/outputs.tf
@@ -1,0 +1,4 @@
+output "public_ip" {
+  value       = oci_core_public_ip.public_ip.ip_address
+  description = "The public IP address"
+}

--- a/infrastructure/modules/public_ip/outputs.tf
+++ b/infrastructure/modules/public_ip/outputs.tf
@@ -1,4 +1,4 @@
 output "public_ip" {
-  value       = oci_core_public_ip.public_ip.ip_address
   description = "The public IP address"
+  value       = oci_core_public_ip.public_ip.ip_address
 }

--- a/infrastructure/modules/public_ip/sources.tf
+++ b/infrastructure/modules/public_ip/sources.tf
@@ -1,0 +1,4 @@
+data "oci_core_private_ips" "private_ip" {
+  subnet_id  = var.subnet_id
+  ip_address = var.private_ip
+}

--- a/infrastructure/modules/public_ip/variables.tf
+++ b/infrastructure/modules/public_ip/variables.tf
@@ -1,0 +1,14 @@
+variable "compartment_id" {
+  description = "OCID of the compartment in which to create the resources"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "The OCID of the subnet where the private IP is located"
+  type        = string
+}
+
+variable "private_ip" {
+  description = "The private IP address to associate the public IP address with"
+  type        = string
+}

--- a/infrastructure/modules/public_ip/versions.tf
+++ b/infrastructure/modules/public_ip/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -2,3 +2,8 @@ output "server_public_ip" {
   description = "The public IP address of the server"
   value       = module.public_ip.public_ip
 }
+
+output "server_domain" {
+  description = "The domain name of the server"
+  value       = module.dns.full_domain
+}

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -1,0 +1,4 @@
+output "server_public_ip" {
+  description = "The public IP address of the server"
+  value       = module.public_ip.public_ip
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -7,19 +7,16 @@ variable "oci_region" {
 variable "oci_tenancy_id" {
   description = "OCI tenancy OCID"
   type        = string
-  sensitive   = true
 }
 
 variable "oci_user_id" {
   description = "OCI user OCID"
   type        = string
-  sensitive   = true
 }
 
 variable "oci_api_fingerprint" {
   description = "OCI API fingerprint"
   type        = string
-  sensitive   = true
 }
 
 variable "oci_api_private_key" {
@@ -31,7 +28,6 @@ variable "oci_api_private_key" {
 variable "oci_compartment_id" {
   description = "OCI compartment OCID"
   type        = string
-  sensitive   = true
 }
 
 variable "oci_resources_name_suffix" {
@@ -49,19 +45,16 @@ variable "cloudflare_api_token" {
 variable "cloudflare_zone_id" {
   description = "ID of the domain on Cloudflare"
   type        = string
-  sensitive   = true
 }
 
 variable "server_subdomain" {
   description = "Subdomain for the server"
   type        = string
-  sensitive   = true
 }
 
 variable "server_port" {
   description = "Port for the server"
   type        = number
-  sensitive   = true
 }
 
 variable "server_ocpus" {
@@ -77,5 +70,4 @@ variable "server_memory_in_gbs" {
 variable "server_ssh_public_key" {
   description = "SSH public key for the server instance"
   type        = string
-  sensitive   = true
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -42,8 +42,8 @@ variable "cloudflare_api_token" {
   sensitive   = true
 }
 
-variable "cloudflare_zone_id" {
-  description = "ID of the domain on Cloudflare"
+variable "cloudflare_domain" {
+  description = "Name of the domain in Cloudflare"
   type        = string
 }
 


### PR DESCRIPTION
Closes #4 
Closes #6 
Closes #7

- Created reserved public ip on OCI
- Associate public ip to compute instance's private ip
- Associate Cloudflare DNS record to public ip
- Filter by domain name instead of zone id on Cloudflare
- Add Terraform outputs for: public ip and server domain
