### PR TITLE
refactor: attach block volume on instance creation

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -35,6 +35,7 @@ module "volume" {
 
   ad_name     = module.ad.name
   size_in_gbs = module.github_env_read.variables["SERVER_BLOCK_VOLUME_SIZE_IN_GBS"]
+  backup_id   = module.github_env_read.variables["SERVER_BLOCK_VOLUME_BACKUP_ID"]
 }
 
 module "instance" {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -27,6 +27,16 @@ module "ad" {
   number         = module.github_env_read.variables["SERVER_AD_NUMBER"]
 }
 
+module "volume" {
+  source = "./modules/oci/volume"
+
+  compartment_id = module.compartment.id
+  name_suffix    = var.github_repository
+
+  ad_name     = module.ad.name
+  size_in_gbs = module.github_env_read.variables["SERVER_BLOCK_VOLUME_SIZE_IN_GBS"]
+}
+
 module "instance" {
   source = "./modules/oci/instance"
 
@@ -39,18 +49,8 @@ module "instance" {
   memory_in_gbs           = module.github_env_read.variables["SERVER_MEMORY_IN_GBS"]
   boot_volume_size_in_gbs = module.github_env_read.variables["SERVER_BOOT_VOLUME_SIZE_IN_GBS"]
   source_image_id         = module.github_env_read.variables["SERVER_SOURCE_IMAGE_ID"]
+  attached_volume_id      = module.volume.id
   ssh_public_key          = module.github_env_read.variables["SERVER_SSH_PUBLIC_KEY"]
-}
-
-module "volume" {
-  source = "./modules/oci/volume"
-
-  compartment_id = module.compartment.id
-  name_suffix    = var.github_repository
-
-  ad_name     = module.ad.name
-  instance_id = module.instance.id
-  size_in_gbs = module.github_env_read.variables["SERVER_BLOCK_VOLUME_SIZE_IN_GBS"]
 }
 
 module "public_ip" {

--- a/infrastructure/modules/github/env_read/outputs.tf
+++ b/infrastructure/modules/github/env_read/outputs.tf
@@ -8,6 +8,7 @@ output "variables" {
     "SERVER_AD_NUMBER"                = local.github_env_vars["SERVER_AD_NUMBER"],
     "SERVER_BOOT_VOLUME_SIZE_IN_GBS"  = local.github_env_vars["SERVER_BOOT_VOLUME_SIZE_IN_GBS"],
     "SERVER_BLOCK_VOLUME_SIZE_IN_GBS" = local.github_env_vars["SERVER_BLOCK_VOLUME_SIZE_IN_GBS"],
+    "SERVER_BLOCK_VOLUME_BACKUP_ID"   = try(local.github_env_vars["SERVER_BLOCK_VOLUME_BACKUP_ID"], ""),
     "SERVER_MEMORY_IN_GBS"            = local.github_env_vars["SERVER_MEMORY_IN_GBS"],
     "SERVER_OCPUS"                    = local.github_env_vars["SERVER_OCPUS"],
     "SERVER_PORT"                     = local.github_env_vars["SERVER_PORT"],

--- a/infrastructure/modules/oci/instance/locals.tf
+++ b/infrastructure/modules/oci/instance/locals.tf
@@ -1,3 +1,4 @@
 locals {
-  instance_name = "instance-${var.name_suffix}"
+  instance_name          = "instance-${var.name_suffix}"
+  volume_attachment_name = "volume_attachment-${var.name_suffix}"
 }

--- a/infrastructure/modules/oci/instance/main.tf
+++ b/infrastructure/modules/oci/instance/main.tf
@@ -30,6 +30,16 @@ resource "oci_core_instance" "instance" {
     skip_source_dest_check    = true
   }
 
+  launch_volume_attachments {
+    type      = "paravirtualized"
+    volume_id = var.attached_volume_id
+
+    display_name                        = local.volume_attachment_name
+    is_pv_encryption_in_transit_enabled = true
+    is_read_only                        = false
+    is_shareable                        = true
+  }
+
   availability_config {
     is_live_migration_preferred = true
     recovery_action             = "RESTORE_INSTANCE"

--- a/infrastructure/modules/oci/instance/variables.tf
+++ b/infrastructure/modules/oci/instance/variables.tf
@@ -58,3 +58,8 @@ variable "ssh_public_key" {
   description = "SSH public key allowed to connect to the instance"
   type        = string
 }
+
+variable "attached_volume_id" {
+  description = "OCID of the block volume to attach to the instance"
+  type        = string
+}

--- a/infrastructure/modules/oci/volume/locals.tf
+++ b/infrastructure/modules/oci/volume/locals.tf
@@ -1,4 +1,3 @@
 locals {
-  volume_name            = "volume-${var.name_suffix}"
-  volume_attachment_name = "volume_attachment-${var.name_suffix}"
+  volume_name = "volume-${var.name_suffix}"
 }

--- a/infrastructure/modules/oci/volume/main.tf
+++ b/infrastructure/modules/oci/volume/main.tf
@@ -15,14 +15,3 @@ resource "oci_core_volume" "volume" {
     }
   }
 }
-
-resource "oci_core_volume_attachment" "volume_attachment" {
-  attachment_type = "paravirtualized"
-  instance_id     = var.instance_id
-  volume_id       = oci_core_volume.volume.id
-
-  display_name                        = local.volume_attachment_name
-  is_pv_encryption_in_transit_enabled = true
-  is_read_only                        = false
-  is_shareable                        = false
-}

--- a/infrastructure/modules/oci/volume/outputs.tf
+++ b/infrastructure/modules/oci/volume/outputs.tf
@@ -1,0 +1,4 @@
+output "id" {
+  description = "The OCID of the volume"
+  value       = oci_core_volume.volume.id
+}

--- a/infrastructure/modules/oci/volume/variables.tf
+++ b/infrastructure/modules/oci/volume/variables.tf
@@ -24,11 +24,6 @@ variable "size_in_gbs" {
   }
 }
 
-variable "instance_id" {
-  description = "OCID of the instance to attach the volume to"
-  type        = string
-}
-
 variable "backup_id" {
   description = "OCID of the volume backup to restore the volume from"
   type        = string


### PR DESCRIPTION
Progress towards #5 

- Separated block volume attachment from creation
- Block volume is attached at instance creation