### PR TITLE
feat: mount block volume with cloud init

### DIFF
--- a/infrastructure/modules/oci/instance/cloud-init.yml
+++ b/infrastructure/modules/oci/instance/cloud-init.yml
@@ -1,5 +1,20 @@
 #cloud-config
 
+disk_setup:
+  /dev/sdb:
+    table_type: gpt
+    layout: true
+    overwrite: false
+
+fs_setup:
+  - device: /dev/sdb1
+    filesystem: ext4
+    label: data
+    overwrite: false
+
+mounts:
+  - [/dev/sdb1, /mnt/data]
+
 packages:
   - apt-transport-https
   - ca-certificates
@@ -24,6 +39,7 @@ runcmd:
     docker-compose-plugin
   - systemctl start docker
   - systemctl enable docker
+  - chown -R ubuntu:docker /mnt/data
 
 groups:
   - docker


### PR DESCRIPTION
Progress towards #5 

- Update cloud init script so that attached block volume is partitioned, formatted and mounted
- These steps should be skipped if block volume is already partition and formatted, and should only be mounted