### PR TITLE
refactor: rename all components to `terraria-server`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ FROM mcr.microsoft.com/devcontainers/base:1-bookworm
 ARG DEVCONTAINER_USER=vscode
 ARG DEVCONTAINER_USER_HOME="/home/${DEVCONTAINER_USER}"
 
-ENV CONTAINER_WORKSPACE_FOLDER="${CONTAINER_WORKSPACE_FOLDER:-/workspaces/terraria-meshi-team}"
+ENV CONTAINER_WORKSPACE_FOLDER="${CONTAINER_WORKSPACE_FOLDER:-/workspaces/terraria-server}"
 
 # Set the pipefail option to ensure correct exit codes for piped commands.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,13 @@
 // Dev Container configuration file.
 // https://aka.ms/devcontainer.json
 {
-  "name": "terraria-meshi-team",
+  "name": "terraria-server",
 
   // Run with Docker Compose.
   // https://code.visualstudio.com/docs/devcontainers/create-dev-container#_use-docker-compose
   "dockerComposeFile": ["../docker-compose.yml"],
   "service": "devcontainer",
-  "workspaceFolder": "/workspaces/terraria-meshi-team",
+  "workspaceFolder": "/workspaces/terraria-server",
 
   // Environment variables for VSCode.
   // https://code.visualstudio.com/remote/advancedcontainers/environment-variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: terraria-server
+
 services:
   devcontainer:
     image: terraria-meshi-team-devcontainer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ name: terraria-server
 
 services:
   devcontainer:
-    image: terraria-meshi-team-devcontainer
-    container_name: terraria-meshi-team-devcontainer
+    image: terraria-server-devcontainer
+    container_name: terraria-server-devcontainer
     build:
       context: .
       dockerfile: .devcontainer/Dockerfile
@@ -14,10 +14,10 @@ services:
       # Mount the Docker daemon socket so the devcontainer can run Docker commands
       - /var/run/docker.sock:/var/run/docker-host.sock
       # Mount the project directory as the working directory
-      - ${LOCAL_WORKSPACE_FOLDER:-.}:${CONTAINER_WORKSPACE_FOLDER:-/workspaces/terraria-meshi-team}
+      - ${LOCAL_WORKSPACE_FOLDER:-.}:${CONTAINER_WORKSPACE_FOLDER:-/workspaces/terraria-server}
       # Mount a volume for node_modules
-      - devcontainer-node_modules:${CONTAINER_WORKSPACE_FOLDER:-/workspaces/terraria-meshi-team}/node_modules
+      - devcontainer-node_modules:${CONTAINER_WORKSPACE_FOLDER:-/workspaces/terraria-server}/node_modules
 
 volumes:
   devcontainer-node_modules:
-    name: terraria-meshi-team-devcontainer-node_modules
+    name: terraria-server-devcontainer-node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "soruba-master",
+  "name": "terraria-server",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "soruba-master",
+      "name": "terraria-server",
       "devDependencies": {
         "eslint": "^9.20.0",
         "eslint-plugin-json": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "soruba-master",
+  "name": "terraria-server",
   "type": "module",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
Possibly breaking, required re-building dev container.

- Added `name: terraria-server` to Docker compose project
- Renamed all instances of `terraria-meshi-team` to `terraria-server`