### PR TITLE
fix: save Terraform server outputs on GitHub as secrets

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -77,7 +77,7 @@ module "github_env_write" {
 
   github_repository = var.github_repository
 
-  variables = {
+  secrets = {
     SERVER_DOMAIN    = module.dns.full_domain
     SERVER_PUBLIC_IP = module.public_ip.public_ip
   }

--- a/infrastructure/modules/github/env_write/main.tf
+++ b/infrastructure/modules/github/env_write/main.tf
@@ -6,3 +6,12 @@ resource "github_actions_variable" "variables" {
   variable_name = each.key
   value         = each.value
 }
+
+resource "github_actions_secret" "secrets" {
+  for_each = var.secrets
+
+  repository = var.github_repository
+
+  secret_name     = each.key
+  plaintext_value = each.value
+}

--- a/infrastructure/modules/github/env_write/variables.tf
+++ b/infrastructure/modules/github/env_write/variables.tf
@@ -6,4 +6,11 @@ variable "github_repository" {
 variable "variables" {
   description = "Map of variables to set in the GitHub repository"
   type        = map(string)
+  default     = {}
+}
+
+variable "secrets" {
+  description = "Map of secrets to set in the GitHub repository"
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
Closes #21 

- Added new resource for creating GitHub actions secrets on `github.env_write` TF module
- Replaced Terraform server outputs from variables to secrets