### PR TITLE
feat: create CI jobs with GitHub actions

### DIFF
--- a/.config/.eslint.config.mjs
+++ b/.config/.eslint.config.mjs
@@ -9,4 +9,8 @@ export default [
     files: ["**/*.json"],
     ...json.configs["recommended-with-comments"],
   },
+  // Ignored files.
+  {
+    ignores: ["**/node_modules", "**/.terraform"],
+  },
 ];

--- a/.config/.hadolint.yml
+++ b/.config/.hadolint.yml
@@ -1,0 +1,13 @@
+# hadolint configuration file.
+# https://github.com/hadolint/hadolint?tab=readme-ov-file#configure
+
+failure-threshold: warning
+
+# Ignored rules.
+ignored:
+  - DL3008
+
+trustedRegistries:
+  - docker.io
+  - ghcr.io
+  - mcr.microsoft.com

--- a/.config/.hadolint.yml
+++ b/.config/.hadolint.yml
@@ -10,4 +10,4 @@ ignored:
 trustedRegistries:
   - docker.io
   - ghcr.io
-  # - mcr.microsoft.com
+  - mcr.microsoft.com

--- a/.config/.hadolint.yml
+++ b/.config/.hadolint.yml
@@ -8,4 +8,5 @@ ignored:
   - DL3008
 
 trustedRegistries:
+  - docker.io
   - ghcr.io

--- a/.config/.hadolint.yml
+++ b/.config/.hadolint.yml
@@ -8,6 +8,4 @@ ignored:
   - DL3008
 
 trustedRegistries:
-  - docker.io
   - ghcr.io
-  - mcr.microsoft.com

--- a/.config/.hadolint.yml
+++ b/.config/.hadolint.yml
@@ -8,5 +8,5 @@ ignored:
   - DL3008
 
 trustedRegistries:
-  - docker.io
+  - mcr.microsoft.com
   - ghcr.io

--- a/.config/.hadolint.yml
+++ b/.config/.hadolint.yml
@@ -8,5 +8,6 @@ ignored:
   - DL3008
 
 trustedRegistries:
-  - mcr.microsoft.com
+  # - docker.io
   - ghcr.io
+  # - mcr.microsoft.com

--- a/.config/.hadolint.yml
+++ b/.config/.hadolint.yml
@@ -8,6 +8,6 @@ ignored:
   - DL3008
 
 trustedRegistries:
-  # - docker.io
+  - docker.io
   - ghcr.io
   # - mcr.microsoft.com

--- a/.config/.prettierignore
+++ b/.config/.prettierignore
@@ -1,1 +1,3 @@
+node_modules
 .editorconfig
+.terraform

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -244,9 +244,11 @@
         // - Use installed hadolint
         "hadolint.hadolintPath": "/usr/local/bin/hadolint",
         // - Configuration location
-        // "hadolint.cliOptions": [
-        //   "--config ${containerWorkspaceFolder}/.config/.hadolint.yml"
-        // ],
+        "hadolint.cliOptions": [
+          "--config",
+          "${containerWorkspaceFolder}/.config/.hadolint.yml",
+          "--no-color"
+        ],
 
         // yamllint
         // - Use installed yamllint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,16 @@ jobs:
       yamllint: ${{ contains(steps.check.outputs.modified_keys, 'yamllint') }}
       eslint: ${{ contains(steps.check.outputs.modified_keys, 'eslint') }}
       prettier: ${{ contains(steps.check.outputs.modified_keys, 'prettier') }}
+    if: |
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request' &&
+        (
+          github.event.action == 'opened' ||
+          github.event.action == 'reopened' ||
+          github.event.action == 'synchronize'
+        )
+      )
     steps:
       - name: Checkout code (on push)
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,9 @@ on:
       - edited
 
 jobs:
-  # Checks if the PR title is valid.
+  # Check if the PR title is valid.
   # A valid title is in the format "<type>(<scope>): <subject>".
+  # -> Fails if the title is invalid.
   validate-pr-title:
     name: Validate PR title
     runs-on: ubuntu-latest
@@ -85,3 +86,68 @@ jobs:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
           header: validate-pr-title
           delete: true
+
+  # Check if Terraform files have been modified.
+  # The output "changed" can be used to check if there are any changes.
+  # -> changed: 'true' if there are changes, 'false' otherwise.
+  tf-files-changed:
+    name: Terraform files changed
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.check.outputs.any_modified }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code (on push)
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Checkout code (on pull request)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Check files for changes
+        id: check
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            **/*.tf
+            **/*.hcl
+
+  # Run terraform fmt on the Terraform files.
+  # -> Fails if there are any formatting issues.
+  tf-fmt:
+    name: Terraform format check
+    runs-on: ubuntu-latest
+    needs:
+      - tf-files-changed
+    if: ${{ needs.tf-files-changed.outputs.changed == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Terraform fmt
+        shell: bash
+        working-directory: ./infrastructure
+        run: terraform fmt -check -recursive -diff -no-color
+
+  # Run terraform validate on the Terraform files.
+  # -> Fails if there are any validation issues.
+  tf-validate:
+    name: Terraform validate
+    runs-on: ubuntu-latest
+    needs:
+      - tf-files-changed
+    if: ${{ needs.tf-files-changed.outputs.changed == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Terraform validate
+        shell: bash
+        working-directory: ./infrastructure
+        run: terraform validate -no-color

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: npm
-          cache-dependency-path: ./package-lock.json
+
+      - name: Install dependencies
+        shell: bash
+        run: npm ci --no-audit --no-progress
 
       - name: Run ESLint
         shell: bash
@@ -210,8 +212,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: npm
-          cache-dependency-path: ./package-lock.json
+
+      - name: Install dependencies
+        shell: bash
+        run: npm ci --no-audit --no-progress
 
       - name: Run prettier
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Terraform fmt
+      - name: Run terraform fmt
         shell: bash
         working-directory: ./infrastructure
         run: terraform fmt -check -recursive -diff -no-color
@@ -151,7 +151,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Terraform validate
+      - name: Run terraform validate
         shell: bash
         working-directory: ./infrastructure
         run: terraform validate -no-color
@@ -167,11 +167,55 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: YAML lint
+      - name: Run yamllint
         uses: ibiqlik/action-yamllint@v3
         with:
           config_file: ./.config/.yamllint.yml
           strict: true
+
+  # Run ESLint on all supported files.
+  # -> Fails if there are any linting issues.
+  eslint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+          cache-dependency-path: ./package-lock.json
+
+      - name: Run ESLint
+        shell: bash
+        run: npm run --silent ci:eslint
+
+  # Run Prettier on all supported files.
+  # -> Fails if there are any formatting issues.
+  prettier:
+    name: Prettier
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+          cache-dependency-path: ./package-lock.json
+
+      - name: Run prettier
+        shell: bash
+        run: npm run --silent ci:prettier
 
   # Block the PR until all checks have passed.
   checks-passed:
@@ -182,6 +226,8 @@ jobs:
       - tf-fmt
       - tf-validate
       - yamllint
+      - eslint
+      - prettier
     if: always()
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,23 @@ jobs:
           config_file: ./.config/.yamllint.yml
           strict: true
 
+  # Run hadolint on all Dockerfiles.
+  # -> Fails if there are any linting issues.
+  hadolint:
+    name: Lint Dockerfiles
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          config: ./.config/.hadolint.yml
+          recursive: true
+
   # Run ESLint on all supported files.
   # -> Fails if there are any linting issues.
   eslint:
@@ -230,6 +247,7 @@ jobs:
       - tf-fmt
       - tf-validate
       - yamllint
+      - hadolint
       - eslint
       - prettier
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,3 +151,18 @@ jobs:
         shell: bash
         working-directory: ./infrastructure
         run: terraform validate -no-color
+
+  # Run yamllint on all YAML files.
+  # -> Fails if there are any linting issues.
+  yamllint:
+    name: YAML lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: YAML lint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: ./.config/.yamllint.yml
+          strict: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,14 +87,14 @@ jobs:
           header: validate-pr-title
           delete: true
 
-  # Check if Terraform files have been modified.
-  # The output "changed" can be used to check if there are any changes.
-  # -> changed: 'true' if there are changes, 'false' otherwise.
-  tf-files-changed:
+  # Check if files have been modified.
+  # The outputs can be used to check if there are any changes.
+  # Each output for that type of check will be 'true' if there are changes.
+  files-changed:
     name: Terraform files changed
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.check.outputs.any_modified }}
+      terraform: ${{ contains(steps.check.outputs.modified_keys, 'terraform') }}
     permissions:
       contents: read
     steps:
@@ -114,9 +114,10 @@ jobs:
         id: check
         uses: tj-actions/changed-files@v45
         with:
-          files: |
-            **/*.tf
-            **/*.hcl
+          files_yaml: |
+            terraform:
+              - "**/*.tf"
+              - "**/*.hcl"
 
   # Run terraform fmt on the Terraform files.
   # -> Fails if there are any formatting issues.
@@ -124,8 +125,8 @@ jobs:
     name: Terraform format check
     runs-on: ubuntu-latest
     needs:
-      - tf-files-changed
-    if: ${{ needs.tf-files-changed.outputs.changed == 'true' }}
+      - files-changed
+    if: ${{ needs.files-changed.outputs.terraform == 'true' }}
     permissions:
       contents: read
     steps:
@@ -143,8 +144,8 @@ jobs:
     name: Terraform validate
     runs-on: ubuntu-latest
     needs:
-      - tf-files-changed
-    if: ${{ needs.tf-files-changed.outputs.changed == 'true' }}
+      - files-changed
+    if: ${{ needs.files-changed.outputs.terraform == 'true' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,7 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           config: ./.config/.hadolint.yml
+          dockerfile: Dockerfile
           recursive: true
 
   # Run yamllint on all YAML files.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
   validate-pr-title:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: |
       github.event_name == 'pull_request' &&
       (
@@ -27,8 +29,6 @@ jobs:
         github.event.action == 'reopened' ||
         github.event.action == 'edited'
       )
-    permissions:
-      contents: read
     steps:
       # This step is done so that the GitHub App (meshi-team-bot)
       # is the author of the PR error comment.
@@ -93,10 +93,15 @@ jobs:
   files-changed:
     name: Terraform files changed
     runs-on: ubuntu-latest
-    outputs:
-      terraform: ${{ contains(steps.check.outputs.modified_keys, 'terraform') }}
     permissions:
       contents: read
+    outputs:
+      terraform: ${{ contains(steps.check.outputs.modified_keys, 'terraform') }}
+      dockerfile: ${{ contains(steps.check.outputs.modified_keys, 'dockerfile') }}
+      yaml: ${{ contains(steps.check.outputs.modified_keys, 'yaml') }}
+      javascript: ${{ contains(steps.check.outputs.modified_keys, 'javascript') }}
+      json: ${{ contains(steps.check.outputs.modified_keys, 'json') }}
+      markdown: ${{ contains(steps.check.outputs.modified_keys, 'markdown') }}
     steps:
       - name: Checkout code (on push)
         if: ${{ github.event_name == 'push' }}
@@ -118,17 +123,30 @@ jobs:
             terraform:
               - "**/*.tf"
               - "**/*.hcl"
+            dockerfile:
+              - "**/*Dockerfile*"
+            yaml:
+              - "**/*.yml"
+              - "**/*.yaml"
+            json:
+              - "**/*.json"
+            markdown:
+              - "**/*.md"
+            javascript:
+              - "**/*.js"
+              - "**/*.mjs"
+              - "**/*.cjs"
 
   # Run terraform fmt on the Terraform files.
   # -> Fails if there are any formatting issues.
   tf-fmt:
     name: Terraform format check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
       - files-changed
     if: ${{ needs.files-changed.outputs.terraform == 'true' }}
-    permissions:
-      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -143,11 +161,11 @@ jobs:
   tf-validate:
     name: Terraform validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
       - files-changed
     if: ${{ needs.files-changed.outputs.terraform == 'true' }}
-    permissions:
-      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -157,23 +175,6 @@ jobs:
         working-directory: ./infrastructure
         run: terraform validate -no-color
 
-  # Run yamllint on all YAML files.
-  # -> Fails if there are any linting issues.
-  yamllint:
-    name: Lint YAML
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Run yamllint
-        uses: ibiqlik/action-yamllint@v3
-        with:
-          config_file: ./.config/.yamllint.yml
-          strict: true
-
   # Run hadolint on all Dockerfiles.
   # -> Fails if there are any linting issues.
   hadolint:
@@ -181,6 +182,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs:
+      - files-changed
+    if: ${{ needs.files-changed.outputs.dockerfile == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -191,6 +195,26 @@ jobs:
           config: ./.config/.hadolint.yml
           recursive: true
 
+  # Run yamllint on all YAML files.
+  # -> Fails if there are any linting issues.
+  yamllint:
+    name: Lint YAML
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - files-changed
+    if: ${{ needs.files-changed.outputs.yaml == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run yamllint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: ./.config/.yamllint.yml
+          strict: true
+
   # Run ESLint on all supported files.
   # -> Fails if there are any linting issues.
   eslint:
@@ -198,6 +222,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs:
+      - files-changed
+    if: |
+      (
+        needs.files-changed.outputs.javascript == 'true' ||
+        needs.files-changed.outputs.json == 'true'
+      )
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -222,6 +253,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs:
+      - files-changed
+    if: |
+      (
+        needs.files-changed.outputs.yaml == 'true' ||
+        needs.files-changed.outputs.javascript == 'true' ||
+        needs.files-changed.outputs.json == 'true' ||
+        needs.files-changed.outputs.markdown == 'true'
+      )
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -243,6 +283,8 @@ jobs:
   checks-passed:
     name: CI checks passed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
       - validate-pr-title
       - tf-fmt
@@ -252,8 +294,6 @@ jobs:
       - eslint
       - prettier
     if: always()
-    permissions:
-      contents: read
     steps:
       - name: Fail if any check failed
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           config: ./.config/.hadolint.yml
-          dockerfile: Dockerfile
+          dockerfile: "**/Dockerfile"
           recursive: true
 
   # Run yamllint on all YAML files.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
   # Run yamllint on all YAML files.
   # -> Fails if there are any linting issues.
   yamllint:
-    name: YAML lint
+    name: Lint YAML
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
   # The outputs can be used to check if there are any changes.
   # Each output for that type of check will be 'true' if there are changes.
   files-changed:
-    name: Terraform files changed
+    name: Check files for changes
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,8 @@ jobs:
     needs:
       - tf-files-changed
     if: ${{ needs.tf-files-changed.outputs.changed == 'true' }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -143,6 +145,8 @@ jobs:
     needs:
       - tf-files-changed
     if: ${{ needs.tf-files-changed.outputs.changed == 'true' }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -157,6 +161,8 @@ jobs:
   yamllint:
     name: YAML lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -166,3 +172,29 @@ jobs:
         with:
           config_file: ./.config/.yamllint.yml
           strict: true
+
+  # Block the PR until all checks have passed.
+  checks-passed:
+    name: CI checks passed
+    runs-on: ubuntu-latest
+    needs:
+      - validate-pr-title
+      - tf-fmt
+      - tf-validate
+      - yamllint
+    if: always()
+    permissions:
+      contents: read
+    steps:
+      - name: Fail if any check failed
+        shell: bash
+        run: |
+          JOBS=$(echo '${{ toJson(needs) }}' | jq -r "keys[]" | xargs)
+
+          for JOB in $JOBS; do
+            RESULT=$(echo '${{ toJson(needs) }}' | jq -r ".[\"$JOB\"].result")
+            if [[ "$RESULT" != "success" && "$RESULT" != "skipped" ]]; then
+              echo "Job: '$JOB' failed with result: '$RESULT'"
+              exit 1
+            fi
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+jobs:
+  # Checks if the PR title is valid.
+  # A valid title is in the format "<type>(<scope>): <subject>".
+  validate-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' &&
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'reopened' ||
+        github.event.action == 'edited'
+      )
+    permissions:
+      contents: read
+    steps:
+      # This step is done so that the GitHub App (meshi-team-bot)
+      # is the author of the PR error comment.
+      - name: Create meshi-team-bot[bot] token
+        uses: actions/create-github-app-token@v1
+        id: token
+        with:
+          app-id: ${{ vars.MESHI_TEAM_BOT_APP_ID }}
+          private-key: ${{ secrets.MESHI_TEAM_BOT_PRIVATE_KEY }}
+
+      - name: Validate PR title
+        id: validate
+        continue-on-error: true
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            revert
+            chore
+            ci
+            docs
+          requireScope: false
+          subjectPattern: ^[a-z].+$
+
+      - name: Add PR comment with error message
+        if: ${{ steps.validate.outputs.error_message != null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+          header: validate-pr-title
+          recreate: true
+          message: |
+            PR title must be in the format `<type>(<scope>): <subject>`.
+
+            - Valid types are: `feat`, `fix`, `refactor`, `revert`, `chore`, `ci`, `docs`.
+            - The scope is optional.
+            - The subject must start with a lowercase letter.
+
+            Change the PR title accordingly.
+
+            Details:
+
+            ```
+            ${{ steps.validate.outputs.error_message }}
+            ```
+
+      - name: Delete PR comment
+        if: ${{ steps.validate.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+          header: validate-pr-title
+          delete: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,10 @@ jobs:
       contents: read
     outputs:
       terraform: ${{ contains(steps.check.outputs.modified_keys, 'terraform') }}
-      dockerfile: ${{ contains(steps.check.outputs.modified_keys, 'dockerfile') }}
-      yaml: ${{ contains(steps.check.outputs.modified_keys, 'yaml') }}
-      javascript: ${{ contains(steps.check.outputs.modified_keys, 'javascript') }}
-      json: ${{ contains(steps.check.outputs.modified_keys, 'json') }}
-      markdown: ${{ contains(steps.check.outputs.modified_keys, 'markdown') }}
+      hadolint: ${{ contains(steps.check.outputs.modified_keys, 'hadolint') }}
+      yamllint: ${{ contains(steps.check.outputs.modified_keys, 'yamllint') }}
+      eslint: ${{ contains(steps.check.outputs.modified_keys, 'eslint') }}
+      prettier: ${{ contains(steps.check.outputs.modified_keys, 'prettier') }}
     steps:
       - name: Checkout code (on push)
         if: ${{ github.event_name == 'push' }}
@@ -123,16 +122,26 @@ jobs:
             terraform:
               - "**/*.tf"
               - "**/*.hcl"
-            dockerfile:
-              - "**/*Dockerfile*"
-            yaml:
+            hadolint:
+              - "./.config/.hadolint.yml"
+              - "**/Dockerfile"
+            yamllint:
+              - "./.config/.yamllint.yml"
               - "**/*.yml"
               - "**/*.yaml"
-            json:
+            eslint:
+              - "./.config/.eslint.config.mjs"
               - "**/*.json"
-            markdown:
+              - "**/*.js"
+              - "**/*.mjs"
+              - "**/*.cjs"
+            prettier:
+              - "./.config/.prettierrc.yml"
+              - "./.config/.prettierignore"
+              - "**/*.yml"
+              - "**/*.yaml"
+              - "**/*.json"
               - "**/*.md"
-            javascript:
               - "**/*.js"
               - "**/*.mjs"
               - "**/*.cjs"
@@ -184,7 +193,7 @@ jobs:
       contents: read
     needs:
       - files-changed
-    if: ${{ needs.files-changed.outputs.dockerfile == 'true' }}
+    if: ${{ needs.files-changed.outputs.hadolint == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -204,7 +213,7 @@ jobs:
       contents: read
     needs:
       - files-changed
-    if: ${{ needs.files-changed.outputs.yaml == 'true' }}
+    if: ${{ needs.files-changed.outputs.yamllint == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -224,11 +233,7 @@ jobs:
       contents: read
     needs:
       - files-changed
-    if: |
-      (
-        needs.files-changed.outputs.javascript == 'true' ||
-        needs.files-changed.outputs.json == 'true'
-      )
+    if: ${{ needs.files-changed.outputs.eslint == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -255,13 +260,7 @@ jobs:
       contents: read
     needs:
       - files-changed
-    if: |
-      (
-        needs.files-changed.outputs.yaml == 'true' ||
-        needs.files-changed.outputs.javascript == 'true' ||
-        needs.files-changed.outputs.json == 'true' ||
-        needs.files-changed.outputs.markdown == 'true'
-      )
+    if: ${{ needs.files-changed.outputs.prettier == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+################################################################################
+# Base image
+# https://github.com/devcontainers/images/tree/main/src/base-debian
+################################################################################
+FROM mcr.microsoft.com/devcontainers/base:1-bookworm
+
+ARG DEVCONTAINER_USER=vscode
+ARG DEVCONTAINER_USER_HOME="/home/${DEVCONTAINER_USER}"
+
+ENV CONTAINER_WORKSPACE_FOLDER="${CONTAINER_WORKSPACE_FOLDER:-/workspaces/terraria-server}"
+
+# Set the pipefail option to ensure correct exit codes for piped commands.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Add aliases for ls
+RUN \
+  echo "alias ls='ls --color=auto'" >> "${DEVCONTAINER_USER_HOME}/.bash_aliases" \
+  && echo "alias ll='ls -alF'" >> "${DEVCONTAINER_USER_HOME}/.bash_aliases" \
+  && echo "alias la='ls -A'" >> "${DEVCONTAINER_USER_HOME}/.bash_aliases" \
+  && echo "alias l='ls -CF'" >> "${DEVCONTAINER_USER_HOME}/.bash_aliases"
+
+# Add alias for cd
+RUN \
+  echo "alias cd='HOME=${CONTAINER_WORKSPACE_FOLDER} cd'" \
+  >> "${DEVCONTAINER_USER_HOME}/.bash_aliases"
+
+# Change the ownership of the mounted volumes to the non-root user
+# Node modules
+RUN \
+  mkdir -p "${CONTAINER_WORKSPACE_FOLDER}/node_modules" \
+  && chown -R "${DEVCONTAINER_USER}:${DEVCONTAINER_USER}" "${CONTAINER_WORKSPACE_FOLDER}/node_modules"

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "terraria-server",
   "type": "module",
   "scripts": {
-    "lint": "eslint .",
-    "lint-fix": "eslint --fix .",
-    "format": "prettier --write ."
+    "lint": "eslint --config ./.config/.eslint.config.mjs .",
+    "lint-fix": "eslint --config ./.config/.eslint.config.mjs --fix .",
+    "format": "prettier --config ./.config/.prettierrc.yml --ignore-path ./.config/.prettierignore --write .",
+    "ci:eslint": "eslint --config ./.config/.eslint.config.mjs --max-warnings 0 --no-color .",
+    "ci:prettier": "prettier --config ./.config/.prettierrc.yml --ignore-path ./.config/.prettierignore --check --no-color ."
   },
   "devDependencies": {
     "eslint": "^9.20.0",


### PR DESCRIPTION
Closes #33

- Created `ci.yml` GitHub actions workflow for CI
  - Created job to validate PR title
  - Created jobs for Terraform (format, validate)
  - Created job to lint YAML with yamllint
  - Created job to lint Dockerfiles with Hadolint
  - Created job to run ESLint
  - Created job to run Prettier
- The CI jobs that run linting/formatting tooling use special filtering to run only if their respective files are modified