### PR TITLE
feat: add ShellCheck linter and create shell script CI jobs

### DIFF
--- a/.config/.shellcheckrc
+++ b/.config/.shellcheckrc
@@ -3,8 +3,9 @@
 
 # Enable all rules
 enable=all
+
+# Directives
 source-path=SCRIPTDIR
+external-sources=true
 
 # Disable specific rules
-# disable=SC2154 # var is referenced but not assigned.
-# disable=SC2312 # Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore).

--- a/.config/.shellcheckrc
+++ b/.config/.shellcheckrc
@@ -1,0 +1,10 @@
+# ShellCheck configuration file
+# https://www.shellcheck.net/wiki/
+
+# Enable all rules
+enable=all
+source-path=SCRIPTDIR
+
+# Disable specific rules
+# disable=SC2154 # var is referenced but not assigned.
+# disable=SC2312 # Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore).

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -144,6 +144,8 @@
         "GitHub.copilot",
         // - Colorize indentation levels
         "oderwat.indent-rainbow",
+        // - Show errors inline
+        "usernamehw.errorlens",
 
         // Editor
         // - .editorconfig support

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,6 +51,12 @@
       "version": "latest"
     },
 
+    // ShellCheck
+    // https://github.com/marcozac/devcontainer-features/tree/main/src/shellcheck
+    "ghcr.io/marcozac/devcontainer-features/shellcheck:1": {
+      "version": "latest"
+    },
+
     // shfmt
     // https://github.com/devcontainers-contrib/features/tree/main/src/shfmt
     "ghcr.io/devcontainers-contrib/features/shfmt:1.0.0": {
@@ -120,7 +126,9 @@
         // - Formatting
         "esbenp.prettier-vscode",
 
-        // shfmt
+        // Shell script
+        // - Linting
+        "timonwong.shellcheck",
         // - Formatting
         "foxundermoon.shell-format",
 
@@ -169,7 +177,8 @@
         "editor.codeActionsOnSave": {
           "source.fixAll": "explicit",
           "source.fixAll.eslint": "explicit",
-          "source.fixAll.markdownlint": "explicit"
+          "source.fixAll.markdownlint": "explicit",
+          "source.fixAll.shellcheck": "explicit"
         },
 
         // Bracket and indentation colors
@@ -229,6 +238,14 @@
         "markdown.extension.toc.omittedFromToc": {
           "README.md": ["## Table of contents", "## Tabla de contenidos"]
         },
+
+        // ShellCheck
+        // - Use installed shellcheck
+        "shellcheck.executablePath": "/usr/local/bin/shellcheck",
+        // - Config file location
+        "shellcheck.customArgs": [
+          "--rcfile=${containerWorkspaceFolder}/.config/.shellcheckrc"
+        ],
 
         // shfmt
         // - Format on save

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
       terraform: ${{ contains(steps.check.outputs.modified_keys, 'terraform') }}
       hadolint: ${{ contains(steps.check.outputs.modified_keys, 'hadolint') }}
       yamllint: ${{ contains(steps.check.outputs.modified_keys, 'yamllint') }}
+      shellcheck: ${{ contains(steps.check.outputs.modified_keys, 'shellcheck') }}
+      shfmt: ${{ contains(steps.check.outputs.modified_keys, 'shfmt') }}
       eslint: ${{ contains(steps.check.outputs.modified_keys, 'eslint') }}
       prettier: ${{ contains(steps.check.outputs.modified_keys, 'prettier') }}
     if: |
@@ -139,6 +141,11 @@ jobs:
               - "./.config/.yamllint.yml"
               - "**/*.yml"
               - "**/*.yaml"
+            shellcheck:
+              - "./.config/.shellcheckrc"
+              - "**/*.sh"
+            shfmt:
+              - "**/*.sh"
             eslint:
               - "./.config/.eslint.config.mjs"
               - "**/*.json"
@@ -234,6 +241,52 @@ jobs:
         with:
           config_file: ./.config/.yamllint.yml
           strict: true
+
+  # Run shellcheck on all shell scripts.
+  # -> Fails if there are any linting issues.
+  shellcheck:
+    name: Lint shell scripts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - files-changed
+    if: ${{ needs.files-changed.outputs.shellcheck == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run shellcheck
+        uses: luizm/action-sh-checker@v0.9.0
+        with:
+          sh_checker_shfmt_disable: true
+          sh_checker_comment: false
+          sh_checker_checkbashisms_enable: false
+        env:
+          SHELLCHECK_OPTS: --rcfile=./.config/.shellcheckrc
+
+  # Run shfmt on all shell scripts.
+  # -> Fails if there are any formatting issues.
+  shfmt:
+    name: Shell script format check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - files-changed
+    if: ${{ needs.files-changed.outputs.shfmt == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run shfmt
+        uses: luizm/action-sh-checker@v0.9.0
+        with:
+          sh_checker_shellcheck_disable: true
+          sh_checker_comment: false
+          sh_checker_checkbashisms_enable: false
+        env:
+          SHFMT_OPTS: --diff
 
   # Run ESLint on all supported files.
   # -> Fails if there are any linting issues.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,8 @@ jobs:
       - tf-validate
       - yamllint
       - hadolint
+      - shellcheck
+      - shfmt
       - eslint
       - prettier
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
   # Run shfmt on all shell scripts.
   # -> Fails if there are any formatting issues.
   shfmt:
-    name: Shell script format check
+    name: Format shell scripts
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,16 +103,6 @@ jobs:
       shfmt: ${{ contains(steps.check.outputs.modified_keys, 'shfmt') }}
       eslint: ${{ contains(steps.check.outputs.modified_keys, 'eslint') }}
       prettier: ${{ contains(steps.check.outputs.modified_keys, 'prettier') }}
-    if: |
-      github.event_name == 'push' ||
-      (
-        github.event_name == 'pull_request' &&
-        (
-          github.event.action == 'opened' ||
-          github.event.action == 'reopened' ||
-          github.event.action == 'synchronize'
-        )
-      )
     steps:
       - name: Checkout code (on push)
         if: ${{ github.event_name == 'push' }}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -9,33 +9,37 @@
 
 # Usage: ./scripts/entrypoint.sh
 
-ENV_SCRIPT="/terraria-server/scripts/load-env.sh"
-CONFIG_SCRIPT="/terraria-server/scripts/generate-server-config.sh"
+DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+ENV_SCRIPT="${DIR}/load-env.sh"
+CONFIG_SCRIPT="${DIR}/generate-server-config.sh"
 
 # Source the environment loading script
-if [ -f "$ENV_SCRIPT" ]; then
-  source "$ENV_SCRIPT"
+if [[ -f "${ENV_SCRIPT}" ]]; then
+  # shellcheck source=SCRIPTDIR/load-env.sh
+  source "${ENV_SCRIPT}"
 else
-  echo "Error: $ENV_SCRIPT not found."
+  echo "Error: ${ENV_SCRIPT} not found."
   exit 1
 fi
 
 # Execute the server config generation script
-if [ -f "$CONFIG_SCRIPT" ]; then
-  "$CONFIG_SCRIPT"
+if [[ -f "${CONFIG_SCRIPT}" ]]; then
+  # shellcheck source=SCRIPTDIR/generate-server-config.sh
+  source "${CONFIG_SCRIPT}"
 else
-  echo "Error: $CONFIG_SCRIPT not found."
+  echo "Error: ${CONFIG_SCRIPT} not found."
   exit 1
 fi
 
 # Create necessary directories
-mkdir -p $WORLDS_FOLDER
-mkdir -p $LOGS_FOLDER
+mkdir -p "${WORLDS_FOLDER}"
+mkdir -p "${LOGS_FOLDER}"
 
-touch $LOGS_FILE
-touch $BANLIST_FILE
+touch "${LOGS_FILE}"
+touch "${BANLIST_FILE}"
 
 # Start the Terraria server
-$SERVER_FOLDER/$SERVER_BIN \
-  -config $CONFIG_FOLDER/$CONFIG_FILE \
-  -logpath $LOGS_FOLDER/$LOGS_FOLDER
+exec "${SERVER_FOLDER}/${SERVER_BIN}" \
+  -config "${CONFIG_FOLDER}/${CONFIG_FILE}" \
+  -logpath "${LOGS_FOLDER}/${LOGS_FOLDER}"

--- a/scripts/generate-server-config.sh
+++ b/scripts/generate-server-config.sh
@@ -7,23 +7,23 @@
 
 set -euo pipefail
 
-TEMPLATE_FILE="$CONFIG_FOLDER/$CONFIG_TEMPLATE"
+TEMPLATE_FILE="${CONFIG_FOLDER:?}/${CONFIG_TEMPLATE:?}"
 
-if [ ! -r "$TEMPLATE_FILE" ]; then
-  echo "Error: Template file '$TEMPLATE_FILE' not found or not readable." >&2
+if [[ ! -r "${TEMPLATE_FILE}" ]]; then
+  echo "Error: Template file '${TEMPLATE_FILE}' not found or not readable." >&2
   exit 1
 fi
 
 # Set the default world seed if not provided
-if [ -z "${WORLD_SEED}" ]; then
+if [[ -z "${WORLD_SEED}" ]]; then
   WORLD_SEED=$((RANDOM * 10000000 + RANDOM))
   export WORLD_SEED
-  echo "WORLD_SEED is not set, generating a random seed: $WORLD_SEED"
+  echo "WORLD_SEED is not set, generating a random seed: ${WORLD_SEED}"
 fi
 
-if ! envsubst < "$TEMPLATE_FILE" > "$CONFIG_FOLDER/$CONFIG_FILE"; then
+if ! envsubst < "${TEMPLATE_FILE}" > "${CONFIG_FOLDER}/${CONFIG_FILE:?}"; then
   echo "Error: Failed to generate server configuration file." >&2
   exit 1
 fi
 
-echo "Server configuration file generated: $CONFIG_FOLDER/$CONFIG_FILE"
+echo "Server configuration file generated: ${CONFIG_FOLDER}/${CONFIG_FILE}"


### PR DESCRIPTION
Closes #35
Closes #39

- Added ShellCheck to dev container to lint shell script files
- Created ShellCheck configuration file under `.config/.shellcheckrc`
- Fixed issues on shell scripts reported by ShellCheck
- Created CI jobs for running ShellCheck and shfmt when shell script files change on PR
- Fixed CI code jobs ability to be bypassed if PR is edited