### PR TITLE
fix: allow new world switching

### DIFF
--- a/config/config-template.cfg
+++ b/config/config-template.cfg
@@ -23,7 +23,7 @@
 #-seed <seed>						Specifies the world seed when using -autocreate
 
 #Load a world and automatically start the server.
-world=${WORLD}
+world=${WORLDS_FOLDER}/${WORLD_NAME}
 
 #Creates a new world if none is found. World size is specified by: 1(small), 2(medium), and 3(large).
 autocreate=${WORLD_SIZE}

--- a/scripts/load-env.sh
+++ b/scripts/load-env.sh
@@ -19,7 +19,6 @@ export LOGS_FILE="${LOGS_FILE:-terraria-server.log}"
 
 # --- World settings ---
 export WORLD_NAME="${WORLD_NAME:-world}"
-export WORLD="${WORLD:-/terraria-server/worlds/world.wld}"
 export WORLD_SIZE="${WORLD_SIZE:-1}"
 export WORLD_ROLLBACKS_TO_KEEP="${WORLD_ROLLBACKS_TO_KEEP:-2}"
 export WORLDS_FOLDER="${WORLDS_FOLDER:-/terraria-server/worlds}"


### PR DESCRIPTION
Closes #36 

## Description
This change adjusts the `-world` flag to ensure it first looks for the world inside the `worlds` folder.  
If the world exists, it will be loaded directly; otherwise, a new one will be created based on the provided parameters.  