### PR TITLE
ci: create release strategy

### DIFF
--- a/.github/release_changelog_config.json
+++ b/.github/release_changelog_config.json
@@ -1,0 +1,27 @@
+{
+  "template": "#{{CHANGELOG}}",
+  "categories": [
+    {
+      "title": "## 🎉 Features",
+      "labels": ["feat"]
+    },
+    {
+      "title": "## 🔧 Bug Fixes and Performance Improvements",
+      "labels": ["fix", "perf"]
+    },
+    {
+      "title": "## 🧹 Maintenance",
+      "labels": ["refactor", "revert", "chore", "ci", "docs"]
+    },
+    {
+      "title": "## Other",
+      "labels": []
+    }
+  ],
+  "label_extractor": [
+    {
+      "pattern": "^(feat|fix|perf|refactor|revert|chore|ci|docs){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
+      "target": "$1"
+    }
+  ]
+}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,119 @@
+name: Bump version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version-increment:
+        description: Version increment type
+        required: true
+        type: choice
+        default: patch
+        options:
+          - major
+          - minor
+          - patch
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref_name == 'main' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Create meshi-team-bot[bot] token
+        uses: actions/create-github-app-token@v1
+        id: token
+        with:
+          app-id: ${{ vars.MESHI_TEAM_BOT_APP_ID }}
+          private-key: ${{ secrets.MESHI_TEAM_BOT_PRIVATE_KEY }}
+
+      - name: Get role of the user who triggered the workflow
+        id: user-role
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          ROLE=$( \
+            gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission |
+            jq -r '.role_name'
+          )
+
+          echo "role=$ROLE" >> $GITHUB_OUTPUT
+
+      - name: Fail if the user's role is not 'admin' or 'maintain'
+        if: ${{ steps.user-role.outputs.role != 'admin' && steps.user-role.outputs.role != 'maintain' }}
+        shell: bash
+        run: exit 1
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Get latest version tag
+        id: latest-version
+        shell: bash
+        run: |
+          git fetch --tags --force
+          TAG=$(
+            git tag -l "v*" |
+            grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" |
+            sort -Vr |
+            head -n1 || echo ""
+          )
+
+          if [[ -z "$TAG" ]]; then
+            TAG="v0.0.0"
+          fi
+
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Bump version tag
+        id: bump-version
+        shell: bash
+        run: |
+          version=$(
+            echo "${{ steps.latest-version.outputs.tag }}" |
+            sed "s/v//"
+          )
+          IFS="." read -r -a version <<< "$version"
+
+          major="${version[0]}"
+          minor="${version[1]}"
+          patch="${version[2]}"
+
+          if [[ "${{ inputs.version-increment }}" == "major" ]]; then
+            major=$((major + 1))
+            minor=0
+            patch=0
+          elif [[ "${{ inputs.version-increment }}" == "minor" ]]; then
+            minor=$((minor + 1))
+            patch=0
+          else
+            patch=$((patch + 1))
+          fi
+
+          echo "tag=v${major}.${minor}.${patch}" >> $GITHUB_OUTPUT
+
+      - name: Push the new version tag
+        shell: bash
+        run: |
+          git tag \
+            "${{ steps.bump-version.outputs.tag }}" \
+            "${{ github.sha }}" \
+            --force
+
+          git push origin \
+            "${{ steps.bump-version.outputs.tag }}" \
+          --force
+
+      - name: Create release
+        shell: bash
+        run: |
+          gh release create \
+            "${{ steps.bump-version.outputs.tag }}" \
+            --title "${{ steps.bump-version.outputs.tag }}" \
+            --notes "Release ${{ steps.bump-version.outputs.tag }}"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -109,11 +109,3 @@ jobs:
           git push origin \
             "${{ steps.bump-version.outputs.tag }}" \
           --force
-
-      - name: Create release
-        shell: bash
-        run: |
-          gh release create \
-            "${{ steps.bump-version.outputs.tag }}" \
-            --title "${{ steps.bump-version.outputs.tag }}" \
-            --notes "Release ${{ steps.bump-version.outputs.tag }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           types: |
             feat
             fix
+            perf
             refactor
             revert
             chore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Create release
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref_name == 'main' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Create meshi-team-bot[bot] token
+        uses: actions/create-github-app-token@v1
+        id: token
+        with:
+          app-id: ${{ vars.MESHI_TEAM_BOT_APP_ID }}
+          private-key: ${{ secrets.MESHI_TEAM_BOT_PRIVATE_KEY }}
+
+      - name: Build Changelog
+        id: build-changelog
+        uses: mikepenz/release-changelog-builder-action@v5
+        with:
+          mode: COMMIT
+          configuration: .github/release_changelog_config.yml
+          failOnError: true
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.build-changelog.outputs.changelog }}
+          generate_release_notes: false
+          draft: false
+          prerelease: false
+          make_latest: true
+          token: ${{ steps.token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   create-release:
     runs-on: ubuntu-latest
-    if: ${{ github.ref_name == 'main' }}
     permissions:
       contents: read
     steps:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Terraria Server 🍕
 
+[![CI status](https://img.shields.io/github/actions/workflow/status/meshi-team/terraria-server/ci.yml?branch=main&event=push&style=flat&label=CI&color=00642E)](https://github.com/meshi-team/terraria-server/actions/workflows/ci.yml?query=branch%3Amain)
+[![Current version](https://img.shields.io/github/v/release/meshi-team/terraria-server?sort=semver&style=flat&label=Version&color=00BAB3)](https://github.com/meshi-team/terraria-server/releases/latest)
+[![Bump version button](https://img.shields.io/badge/Bump_version-4200C8?style=flat)](https://github.com/meshi-team/terraria-server/actions/workflows/bump-version.yml)
+
 A Docker-based Terraria server setup that lets you quickly deploy and manage a Terraria multiplayer server. This repository provides a fully containerized Terraria server that's easy to configure and run on any system that supports Docker. It uses the official Terraria server application, wrapped in a Docker container for consistency and portability.
 
 The server:

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The DevContainer includes all necessary development tools:
 4. Run linting and formatting checks before committing
 5. Submit a pull request with a conventional commit title:
    - Format: `<type>(<scope>): <subject>`
-   - Valid types: `feat`, `fix`, `refactor`, `revert`, `chore`, `ci`, `docs`
+   - Valid types: `feat`, `fix`, `perf`, `refactor`, `revert`, `chore`, `ci`, `docs`
 6. Ensure all CI checks pass
 
 ### Workflow Tools


### PR DESCRIPTION
Closes #48
Closes #52

- Created `bump-version.yml` workflow to bump the version of the repository via semver tags
- Created `release.yml` workflow to create GitHub releases when a new semver tag is pushed
- Updated README to add informative badges (CI status, current version, button to bump version)