### PR TITLE
build: vanilla server image

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The server:
 
 Currently available profiles:
 
-- **vanilla**: The official Terraria server - [version](./server/vanilla/terraria-version)
+- **vanilla**: The official Terraria server - [version](./server/vanilla/terraria-version) | [documentation](./server/vanilla/README.md)
 
 Coming soon:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   vanilla-server:
     build:
       context: server/vanilla/.
+    # Use the line below instead of the build context if you want to use the pre-built image
+    # image: ghcr.io/meshi-team/terraria-server-vanilla:latest
     container_name: vanilla-server
     ports:
       - 7777:7777 # Default Terraria server port

--- a/server/vanilla/Dockerfile
+++ b/server/vanilla/Dockerfile
@@ -1,5 +1,29 @@
 FROM mono:slim
 
+# Build-time arguments for dynamic labels
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+ARG DOCS
+
+# New labels following OCI Image Spec
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.title="Terraria Server Vanilla"
+LABEL org.opencontainers.image.url="https://github.com/meshi-team/terraria-server"
+LABEL org.opencontainers.image.documentation="https://github.com/meshi-team/terraria-server/$DOCS"
+LABEL org.opencontainers.image.vendor="Meshi Team"
+
+# Additional helpful labels
+LABEL com.terraria.version="${VERSION}"
+LABEL io.github.meshi-team.terraria-server.maintainer="Meshi Team"
+LABEL io.github.meshi-team.terraria-server.is-production="true"
+
+LABEL org.opencontainers.image.description="Terraria dedicated server (v$VERSION) container image with persistent world storage and customizable configuration."
+LABEL org.opencontainers.image.source="https://github.com/meshi-team/terraria-server"
+LABEL org.opencontainers.image.licenses="MIT"
+
 # Install dependencies
 RUN apt-get update \
   && apt-get upgrade -y \

--- a/server/vanilla/README.md
+++ b/server/vanilla/README.md
@@ -1,0 +1,172 @@
+# Terraria Server Vanilla
+
+[![GitHub Container Registry](https://img.shields.io/badge/GitHub%20Container%20Registry-available-green)](https://github.com/meshi-team/terraria-server/pkgs/container/terraria-server-vanilla)
+![Platform Support](https://img.shields.io/badge/platform-linux%2Famd64%20%7C%20linux%2Farm64%20%7C%20linux%2Farm%2Fv7-blue)
+
+This container image provides a ready-to-use Terraria dedicated server with persistent world storage and customizable configuration.
+
+## Features
+
+- Multi-architecture support: runs on `linux/amd64`, `linux/arm64`, and `linux/arm/v7`
+- Configurable server properties through environment variables
+- Persistent world storage via Docker volumes
+- Based on the official Terraria server binaries
+- Minimal dependencies for optimal performance
+
+## Quick Start
+
+```bash
+docker run -d \
+  --name terraria-server \
+  -p 7777:7777 \
+  -e WORLD_NAME=myworld \
+  -e WORLD_SIZE=2 \
+  -e DIFFICULTY=0 \
+  -e MAX_PLAYERS=8 \
+  -v terraria-worlds:/terraria-server/worlds \
+  ghcr.io/meshi-team/terraria-server-vanilla
+```
+
+## Docker Compose Setup
+
+Create a `docker-compose.yml` file with the following contents:
+
+```yaml
+version: "3"
+
+services:
+  vanilla-server:
+    image: ghcr.io/meshi-team/terraria-server-vanilla
+    container_name: vanilla-server
+    ports:
+      - 7777:7777 # Default Terraria server port
+    environment:
+      - WORLD_NAME=world
+      - WORLD_SIZE=2 # 1=small, 2=medium, 3=large
+      - WORLD_SEED=
+      - PASSWORD=
+      - DIFFICULTY=0 # 0=normal, 1=expert, 2=master, 3=journey
+      - MAX_PLAYERS=8
+    volumes:
+      - vanilla-worlds:/terraria-server/worlds
+    restart: unless-stopped
+    tty: true
+    stdin_open: true
+
+volumes:
+  vanilla-worlds:
+    driver: local
+```
+
+Then run:
+
+```bash
+docker compose up -d
+```
+
+## Environment Variables
+
+| Variable        | Default Value            | Description                   |
+| --------------- | ------------------------ | ----------------------------- |
+| SERVER_FOLDER   | /terraria-server         | Main server directory         |
+| SERVER_BIN      | TerrariaServer           | Server binary name            |
+| CONFIG_FOLDER   | /terraria-server/config  | Configuration directory       |
+| CONFIG_FILE     | server-config.txt        | Server configuration filename |
+| CONFIG_TEMPLATE | config-template.cfg      | Template configuration file   |
+| SCRIPTS_FOLDER  | /terraria-server/scripts | Scripts directory             |
+| LOGS_FOLDER     | /terraria-server/logs    | Logs directory                |
+| LOGS_FILE       | terraria-server.log      | Log filename                  |
+
+### World Settings
+
+| Variable                | Default Value | Description                                |
+| ----------------------- | ------------- | ------------------------------------------ |
+| WORLD_NAME              | world         | World name                                 |
+| WORLD_SIZE              | 1             | World size (1: small, 2: medium, 3: large) |
+| WORLD_ROLLBACKS_TO_KEEP | 2             | Number of world backups to maintain        |
+| WORLD_SEED              | ""            | World generation seed                      |
+
+### Game Settings
+
+| Variable     | Default Value                | Description                                                    |
+| ------------ | ---------------------------- | -------------------------------------------------------------- |
+| DIFFICULTY   | 0                            | Game difficulty (0: classic, 1: expert, 2: master, 3: journey) |
+| MAX_PLAYERS  | 8                            | Maximum number of players allowed                              |
+| PORT         | 7777                         | Server port                                                    |
+| PASSWORD     | password                     | Server password                                                |
+| MOTD         | "Welcome to my server!"      | Message of the day                                             |
+| BANLIST_FILE | /terraria-server/banlist.txt | Path to banlist file                                           |
+| SECURE       | 1                            | Enable secure mode (1: on, 0: off)                             |
+| LANGUAGE     | en-US                        | Server language                                                |
+| UPNP         | 1                            | Enable UPnP (1: on, 0: off)                                    |
+| NPC_STREAM   | 60                           | NPC stream range                                               |
+| PRIORITY     | 1                            | Process priority                                               |
+| SLOW_LIQUIDS | 1                            | Enable slow liquids (1: on, 0: off)                            |
+| ENABLE_STEAM | 0                            | Enable Steam integration (1: on, 0: off)                       |
+
+## Volume Management
+
+The server uses a persistent volume at `/terraria-server/worlds` to store all world data. This ensures your world files persist even if the container is removed or recreated.
+
+To backup your worlds, you can copy files from the Docker volume:
+
+```bash
+# List volume contents
+docker run --rm -v vanilla-worlds:/data -w /data busybox ls -la
+
+# Copy worlds to host system
+docker run --rm -v vanilla-worlds:/data -v $(pwd)/backups:/backup busybox cp -r /data/* /backup
+```
+
+## Server Management
+
+### Accessing the Console
+
+To access the running server console:
+
+```bash
+docker attach vanilla-server
+```
+
+Press `Ctrl+P` followed by `Ctrl+Q` to detach without stopping the server.
+
+### Server Commands
+
+While attached to the console, you can use these commands:
+
+- `help` - Shows available commands
+- `exit` - Saves and exits
+- `save` - Saves the world
+- `kick <player>` - Kicks a player
+- `ban <player>` - Bans a player
+- `playing` - Shows connected players
+- `version` - Shows server version
+
+### Stopping the Server
+
+To properly stop the server, either:
+
+1. Attach to the console and enter the `exit` command
+2. Use `docker stop vanilla-server` (the container will attempt a graceful shutdown)
+
+## Troubleshooting
+
+### Container Exits Immediately
+
+Check the logs for errors:
+
+```bash
+docker logs vanilla-server
+```
+
+### World Not Loading
+
+Ensure the `WORLD_NAME` matches an existing world in your volume, or set `AUTOCREATE` to generate a new world.
+
+### Connection Issues
+
+Make sure port 7777 is properly exposed and not blocked by firewalls.
+
+## License
+
+This container image is available under the MIT License. Terraria itself is owned by Re-Logic.


### PR DESCRIPTION
This pull request introduces several improvements and new features for the Terraria server setup. The changes include updating documentation, enhancing the Docker setup, and adding new labels for the Docker image.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R88): Added a link to the documentation for the vanilla server profile.
* [`server/vanilla/README.md`](diffhunk://#diff-d2bac8dcd3a7bc0a178b634905de2e28894806bea4eeb0937a88e1abd47f5111R1-R172): Created a comprehensive README for the vanilla server, including features, quick start guide, Docker Compose setup, environment variables, volume management, server management, and troubleshooting.

### Docker Enhancements:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R5-R6): Added a commented-out option to use a pre-built image instead of building from the context.
* [`server/vanilla/Dockerfile`](diffhunk://#diff-e3cca21609e01d50831117853408b152339523091cdd9205d3f1ffc270bda243R3-R26): Introduced build-time arguments and new labels following the OCI Image Spec, providing metadata such as build date, version, VCS reference, and documentation URL.