### PR TITLE
feat: add TShock server support and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The server:
 > Run a Terraria Mobile Edition server using the new `mobile` profile.
 > See [server/mobile/README.md](./server/mobile/README.md) for details.
 
+> **TShock support is now available!**
+> Run a TShock-enabled Terraria server using the new `tshock` profile.
+> See the [TShock Wiki](https://github.com/Pryaxis/TShock/wiki) for advanced configuration, plugins, and moderation tools.
+
 ## Table of contents
 
 - [Requirements](#requirements)
@@ -25,6 +29,7 @@ The server:
   - [Prebuilt Images](#prebuilt-images)
   - [From Source](#from-source)
   - [Server Profiles](#server-profiles)
+  - [TShock Server](#tshock-server)
   - [Configuration](#configuration)
   - [Environment Variables](#environment-variables)
   - [Init Settings](#init-settings)
@@ -110,8 +115,8 @@ To build and run the server from source, follow these steps:
    # Start the Terraria Mobile server
    docker compose --profile mobile up -d
 
-   # Coming soon - TShock server
-   # docker compose --profile tshock up -d
+   # Start the TShock server
+   docker compose --profile tshock up -d
    ```
 
 3. **View server logs**:
@@ -132,10 +137,21 @@ Currently available profiles:
 
 - **vanilla**: The official Terraria server (PC) - [version](./server/vanilla/terraria-version) | [documentation](./server/vanilla/README.md)
 - **mobile**: Terraria Mobile Edition server - [version](./server/mobile/terraria-version) | [documentation](./server/mobile/README.md)
-
-Coming soon:
-
 - **tshock**: TShock server with advanced moderation tools and plugin support
+
+### TShock Server
+
+The TShock server provides advanced moderation, REST API, and plugin support for Terraria.  
+To use TShock, start the server with the `tshock` profile:
+
+```bash
+docker compose --profile tshock up -d
+```
+
+TShock data, configuration, and plugins are stored in the `./tshock`, `./worlds`, and `./plugins` directories (mounted as volumes).  
+The REST API is available on port `7878` by default.
+
+For more information, configuration options, and plugin management, see the [TShock Wiki](https://github.com/Pryaxis/TShock/wiki).
 
 ### Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,23 @@ services:
     tty: true
     stdin_open: true
 
+  tshock-server:
+    image: ghcr.io/pryaxis/tshock
+    container_name: tshock-server
+    restart: unless-stopped
+    volumes:
+      - ./tshock/:/tshock
+      - ./worlds:/worlds
+      - ./plugins:/plugins
+      - /etc/localtime:/etc/localtime:ro
+    ports:
+      - 7777:7777
+      - 7878:7878
+    command: -world /worlds/my_world.wld
+    profiles: [tshock]
+    tty: true
+    stdin_open: true
+
 volumes:
   vanilla-worlds:
     driver: local


### PR DESCRIPTION
This pull request introduces support for running a TShock-enabled Terraria server, including updates to the documentation and `docker-compose.yml` configuration. The most important changes focus on enabling the new `tshock` profile, providing advanced moderation tools, plugin support, and REST API functionality.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R32): Added instructions for running a TShock server using the new `tshock` profile, including details on configuration, data storage, and REST API usage. Linked to the [TShock Wiki](https://github.com/Pryaxis/TShock/wiki) for further information. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R119) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R140-R154)

### Configuration Changes:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R47-R63): Added a new `tshock-server` service with appropriate image, container settings, volume mounts, and port mappings. The `tshock` profile is now available for use with Docker Compose.