### PR TITLE
ci: restart image tag fruit sequence for each terraria version

### DIFF
--- a/.github/actions/build-images/action.yml
+++ b/.github/actions/build-images/action.yml
@@ -57,6 +57,7 @@ runs:
         # Read version sequence from JSON file
         readarray -t AVAILABLE_TAGS < <(jq -r '.[]' ./.github/image_versions.json)
 
+        VERSION="${{ steps.read-version.outputs.version }}"
         PKG_NAME="${{ inputs.repository-prefix }}-${{ inputs.server-type }}"
         echo "package-name=$PKG_NAME" >> $GITHUB_OUTPUT
 
@@ -64,15 +65,17 @@ runs:
           --creds "${{ github.actor }}:${{ inputs.token }}" \
           | jq -r '.Tags[]' 2>/dev/null || echo "")
 
+        # The sequence restarts for every new Terraria version, so only
+        # tags belonging to the current version count as taken
         NEXT_TAG="${AVAILABLE_TAGS[0]}"  # Default to first element
         for tag in "${AVAILABLE_TAGS[@]}"; do
-          if ! echo "$EXISTING_TAGS" | grep -qw "$tag"; then
+          if ! echo "$EXISTING_TAGS" | grep -qx "${VERSION}-${tag}"; then
             NEXT_TAG="$tag"
             break
           fi
         done
 
-        echo "image-tag=${{ steps.read-version.outputs.version }}-$NEXT_TAG" >> $GITHUB_OUTPUT
+        echo "image-tag=${VERSION}-$NEXT_TAG" >> $GITHUB_OUTPUT
 
     - name: Get current timestamp
       id: timestamp


### PR DESCRIPTION
## Problem

The fruit availability check in `.github/actions/build-images/action.yml` matched the fruit name as a bare word (`grep -qw`) against every existing GHCR tag. Since the hyphen in `1.4.4.9-apple` counts as a word boundary, a fruit used by **any** previous Terraria version was considered taken forever, turning the fruit list into a global counter per image instead of a per-version sequence.

For example, with `1.4.4.9-apple` and `1.4.4.9-banana` already published, the first build of `1.4.5.0` would have been tagged `1.4.5.0-cherry` instead of `1.4.5.0-apple`.

## Fix

Compare the full `<version>-<fruit>` tag with an exact line match (`grep -qx`), so the sequence restarts at the first fruit for each new Terraria version.

| Scenario | Existing tags | Before | After |
| --- | --- | --- | --- |
| New Terraria version | `1.4.4.9-apple`, `1.4.4.9-banana` | `1.4.5.0-cherry` | `1.4.5.0-apple` |
| Rebuild of same version | `1.4.4.9-apple`, `1.4.4.9-banana` | `1.4.4.9-cherry` | `1.4.4.9-cherry` |
| First build ever | — | `1.4.4.9-apple` | `1.4.4.9-apple` |